### PR TITLE
refactor: use protocol as bufname instead

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -48,7 +48,7 @@ export async function note(args: {
     return ActionFlags.None;
   }
 
-  const bufname = `ddu-source-redmine_#${item.issue.id}-note`;
+  const bufname = `redmine:///note#${item.issue.id}`;
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
 
   await fn.setbufline(

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -29,7 +29,7 @@ export async function update(args: {
     return ActionFlags.None;
   }
 
-  const bufname = `ddu-source-redmine_#${item.issue.id}-update`;
+  const bufname = `redmine:///update#${item.issue.id}`;
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
   try {
     await fn.setbufline(

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -27,7 +27,7 @@ export async function updateDescription(args: {
     return ActionFlags.None;
   }
 
-  const bufname = `ddu-source-redmine_#${item.issue.id}-description`;
+  const bufname = `redmine:///description#${item.issue.id}`;
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
   await fn.setbufline(
     denops,


### PR DESCRIPTION
SSIA

pros:
- easy to define autocmd by user


