### PR TITLE
feat: update `title` with `description` when `updateDescription`

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -4,7 +4,7 @@ import {
   ActionFlags,
   type DduItem,
 } from "jsr:@shougo/ddu-vim@10.4.0/types";
-import { type Denops } from "jsr:@denops/std@7.6.0";
+import type { Denops } from "jsr:@denops/std@7.6.0";
 import * as fn from "jsr:@denops/std@7.6.0/function";
 import { define } from "jsr:@denops/std@7.6.0/autocmd";
 import { batch } from "jsr:@denops/std@7.6.0/batch";
@@ -12,10 +12,12 @@ import { add } from "jsr:@denops/std@7.6.0/lambda";
 import { expr } from "jsr:@denops/std@7.6.0/eval";
 import { format } from "jsr:@denops/std@7.6.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@7.6.0/option";
+import { stringify } from "jsr:@std/yaml@1.0.9";
+import { extractYaml } from "jsr:@std/front-matter@1.0.9";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
 import { update as updateIssue } from "https://deno.land/x/deno_redmine@v0.10.0/issues/update.ts";
 import { isItem, type Params } from "../type.ts";
-import { assert, is } from "jsr:@core/unknownutil@4.3.0";
+import { as, assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { getEditCommand } from "../getEditCommand.ts";
 
 const callback: ActionCallback<Params> = async (args: {
@@ -41,21 +43,34 @@ const callback: ActionCallback<Params> = async (args: {
   });
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
 
+  const lines = [
+    "---",
+    stringify({
+      id: item.issue.id,
+      title: item.issue.subject,
+    }),
+    "---",
+    "",
+    item.issue.description ?? "",
+  ]
+    .flatMap((e) => e.trim().split(/\r?\n/));
   await batch(denops, async (d) => {
     await fn.setbufline(
       d,
       bufnr,
       1,
-      (item.issue.description ?? "").split(/\r?\n/),
+      lines,
     );
     await filetype.setBuffer(d, bufnr, "markdown");
     await modified.setBuffer(d, bufnr, false);
 
     const lambda = add(d, async (lines: unknown) => {
       assert(lines, is.ArrayOf(is.String));
+      const { attrs, body } = extractYaml(lines.join("\n").trim());
+      assert(attrs, is.ObjectOf({ title: as.Optional(is.String) }));
       await updateIssue(
         item.issue.id,
-        { description: lines.join("\n").trim() },
+        { subject: attrs.title ?? "", description: body },
         item,
       );
     });

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -70,7 +70,7 @@ const callback: ActionCallback<Params> = async (args: {
       assert(attrs, is.ObjectOf({ title: as.Optional(is.String) }));
       await updateIssue(
         item.issue.id,
-        { subject: attrs.title ?? "", description: body },
+        { subject: attrs.title ?? item.issue.subject, description: body },
         item,
       );
     });

--- a/denops/ddu-source-redmine/issue/type.ts
+++ b/denops/ddu-source-redmine/issue/type.ts
@@ -3,22 +3,26 @@ import { as, is, type Predicate } from "jsr:@core/unknownutil@4.3.0";
 export type Item = {
   issue: {
     id: number;
+    subject: string;
     description: string | undefined;
   };
   endpoint: string;
   apiKey: string;
 };
 
+export const isIssue = is.ObjectOf({
+  id: is.Number,
+  subject: is.String,
+  description: is.UnionOf([
+    is.String,
+    is.Undefined,
+  ]),
+}) satisfies Predicate<Item["issue"]>;
+
 export const isItem = is.ObjectOf({
-  issue: is.ObjectOf({
-    id: is.Number,
-    description: is.UnionOf([
-      is.String,
-      is.Undefined,
-    ]),
-  }),
   endpoint: is.String,
   apiKey: is.String,
+  issue: isIssue,
 }) satisfies Predicate<Item>;
 
 export const mayHasCommand = is.ObjectOf({


### PR DESCRIPTION
- **refactor: add subject type**
- **feat: update title with description by `updateDescription`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Structured editing for Redmine issues: the editor now shows a YAML header (id and title) above the description.
  - Edit title and description together; saving updates both the issue subject and description in Redmine.
  - Issue items now include the subject/title, improving clarity in lists and previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->