### PR TITLE
refactor: stop to use `std/url/join`

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/open.ts
+++ b/denops/ddu-source-redmine/issue/actions/open.ts
@@ -6,7 +6,7 @@ import {
 } from "jsr:@shougo/ddu-vim@10.4.0/types";
 import type { Denops } from "jsr:@denops/std@7.6.0";
 import { isItem, type Item, type Params } from "../type.ts";
-import { join } from "jsr:@std/path@0.225.1/join";
+import { join } from "jsr:@std/path@0.225.1/posix";
 import { systemopen } from "jsr:@lambdalisue/systemopen@1.0.0";
 
 function issueUrl(issueItem: Item): URL {

--- a/denops/ddu-source-redmine/issue/actions/open.ts
+++ b/denops/ddu-source-redmine/issue/actions/open.ts
@@ -6,11 +6,11 @@ import {
 } from "jsr:@shougo/ddu-vim@10.4.0/types";
 import type { Denops } from "jsr:@denops/std@7.6.0";
 import { isItem, type Item, type Params } from "../type.ts";
-import { join } from "jsr:@std/url@0.225.1/join";
+import { join } from "jsr:@std/path@0.225.1/join";
 import { systemopen } from "jsr:@lambdalisue/systemopen@1.0.0";
 
 function issueUrl(issueItem: Item): URL {
-  return join(issueItem.endpoint, "issues", `${issueItem.issue.id}`);
+  return new URL(join(issueItem.endpoint, "issues", `${issueItem.issue.id}`));
 }
 
 const callback: ActionCallback<Params> = async (args: {


### PR DESCRIPTION
It is deprecated, use `std/path/join` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability when opening Redmine issue links to prevent occasional malformed URLs.

- Refactor
  - Internal URL handling standardized for greater consistency and stability.

- Chores
  - Updated standard library usage to improve compatibility.

- Tests
  - None

- Documentation
  - None

- Style
  - None

- Revert
  - None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->