### PR TITLE
ci: add release environment to release-please job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Add `environment: release` to the `release-please` job so that release secrets are scoped to a specific environment.

## Details

The `release-please` job references `RELEASE_APP_ID` and `RELEASE_PRIVATE_KEY` secrets. By associating the job with the `release` environment, these secrets can be restricted to that environment, providing better access control and reducing the risk of unintended exposure.

## Confirmation

- Verify that CI passes on this PR.
- Confirm the `release` environment exists in the repository settings with the required secrets configured.

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to enhance deployment management and process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->