### PR TITLE
chore(deps): update dependency @omochice/redmine to v3.2.0

### DIFF
--- a/denops/@ddu-sources/redmine_issue.ts
+++ b/denops/@ddu-sources/redmine_issue.ts
@@ -5,8 +5,7 @@ import {
 } from "jsr:@shougo/ddu-vim@11.3.0/types";
 import { BaseSource } from "jsr:@shougo/ddu-vim@11.3.0/source";
 import type { Denops } from "jsr:@denops/std@8.2.0";
-import { listIssues } from "jsr:@omochice/redmine@2.3.1/result/issues/list";
-import type { Issue } from "jsr:@omochice/redmine@2.3.1/throwable/issues/type";
+import { type Issue, listIssues } from "../ddu-source-redmine/redmine.ts";
 import { type ActionData, kindName } from "../@ddu-kinds/redmine_issue.ts";
 import type { Context } from "../ddu-source-redmine/issue/type.ts";
 

--- a/denops/@ddu-sources/redmine_project.ts
+++ b/denops/@ddu-sources/redmine_project.ts
@@ -5,8 +5,7 @@ import {
 } from "jsr:@shougo/ddu-vim@11.3.0/types";
 import { BaseSource } from "jsr:@shougo/ddu-vim@11.3.0/source";
 import type { Denops } from "jsr:@denops/std@8.2.0";
-import { fetchList } from "jsr:@omochice/redmine@2.3.1/result/projects/list";
-import type { Project } from "jsr:@omochice/redmine@2.3.1/throwable/projects/type";
+import { listProjects, type Project } from "../ddu-source-redmine/redmine.ts";
 import { type ActionData, kindName } from "../@ddu-kinds/redmine_project.ts";
 
 type Context = {
@@ -80,7 +79,7 @@ export class Source extends BaseSource<Params> {
 type ProjectMap = Map<string, Project[]>;
 
 async function fetchProjectMap(ctx: Context): Promise<ProjectMap> {
-  const result = await fetchList(ctx);
+  const result = await listProjects(ctx);
   if (result.isErr()) {
     throw new Error("Failed to fetch projects", { cause: result.error });
   }

--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -70,15 +70,23 @@ const callback: ActionCallback<Params> = async (args: {
     await modified.setBuffer(d, bufnr, false);
     const lambda = add(d, async (lines: unknown) => {
       assert(lines, is.ArrayOf(is.String));
+      let note: Note;
       try {
         const { attrs, body } = extractYaml<NoteOption>(lines.join("\n"));
-        const note = {
+        note = {
           notes: body.trim(),
           private_notes: attrs.private_notes ?? false,
         } satisfies Note;
-        await update(item, item.issue.id, note);
       } catch {
         await echoerr(d, `Content is invalid format: ${lines.join("\n")}`);
+        return;
+      }
+      const result = await update(item, item.issue.id, note);
+      if (result.isErr()) {
+        await echoerr(
+          d,
+          `Failed to add a note to issue #${item.issue.id}: ${result.error}`,
+        );
       }
     });
 

--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -16,7 +16,7 @@ import { expr } from "jsr:@denops/std@8.2.0/eval";
 import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
-import { update } from "jsr:@omochice/redmine@2.3.1/result/issues/update";
+import { updateIssue as update } from "../../redmine.ts";
 import { assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { isItem, type Params } from "../type.ts";
 import { getEditCommand } from "../getEditCommand.ts";

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -14,7 +14,7 @@ import { expr } from "jsr:@denops/std@8.2.0/eval";
 import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
-import { update as updateIssue } from "jsr:@omochice/redmine@2.3.1/result/issues/update";
+import { updateIssue } from "../../redmine.ts";
 import { isItem, type Params } from "../type.ts";
 import { assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { getEditCommand } from "../getEditCommand.ts";

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -57,17 +57,25 @@ const callback: ActionCallback<Params> = async (args: {
 
   const lambda = add(denops, async (lines: unknown) => {
     assert(lines, is.ArrayOf(is.String));
+    let content: ReturnType<typeof parse>;
     try {
-      const content = parse(lines.join("\n"));
-      await updateIssue(
-        item,
-        item.issue.id,
-        content,
-      );
+      content = parse(lines.join("\n"));
     } catch {
       await echoerr(
         denops,
         `Content is invalid toml format: ${lines.join("\n")}`,
+      );
+      return;
+    }
+    const result = await updateIssue(
+      item,
+      item.issue.id,
+      content,
+    );
+    if (result.isErr()) {
+      await echoerr(
+        denops,
+        `Failed to update issue #${item.issue.id}: ${result.error}`,
       );
     }
   });

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -7,6 +7,7 @@ import {
 import type { Denops } from "jsr:@denops/std@8.2.0";
 import * as fn from "jsr:@denops/std@8.2.0/function";
 import { define } from "jsr:@denops/std@8.2.0/autocmd";
+import { echoerr } from "jsr:@denops/std@8.2.0/helper";
 import { batch } from "jsr:@denops/std@8.2.0/batch";
 import { add } from "jsr:@denops/std@8.2.0/lambda";
 import { expr } from "jsr:@denops/std@8.2.0/eval";
@@ -68,11 +69,17 @@ const callback: ActionCallback<Params> = async (args: {
       assert(lines, is.ArrayOf(is.String));
       const { attrs, body } = extractYaml(lines.join("\n").trim());
       assert(attrs, is.ObjectOf({ title: as.Optional(is.String) }));
-      await updateIssue(
+      const result = await updateIssue(
         item,
         item.issue.id,
         { subject: attrs.title ?? item.issue.subject, description: body },
       );
+      if (result.isErr()) {
+        await echoerr(
+          d,
+          `Failed to update issue #${item.issue.id}: ${result.error}`,
+        );
+      }
     });
 
     const command = getEditCommand(actionParams, kindParams);

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -15,7 +15,7 @@ import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
 import { stringify } from "jsr:@std/yaml@1.2.0";
 import { extractYaml } from "jsr:@std/front-matter@1.0.9";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
-import { update as updateIssue } from "jsr:@omochice/redmine@2.3.1/result/issues/update";
+import { updateIssue } from "../../redmine.ts";
 import { isItem, type Params } from "../type.ts";
 import { as, assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { getEditCommand } from "../getEditCommand.ts";

--- a/denops/ddu-source-redmine/redmine.ts
+++ b/denops/ddu-source-redmine/redmine.ts
@@ -1,0 +1,6 @@
+export { listIssues } from "jsr:@omochice/redmine@2.3.1/result/issues/list";
+export { update as updateIssue } from "jsr:@omochice/redmine@2.3.1/result/issues/update";
+export { fetchList as listProjects } from "jsr:@omochice/redmine@2.3.1/result/projects/list";
+
+export type { Issue } from "jsr:@omochice/redmine@2.3.1/throwable/issues/type";
+export type { Project } from "jsr:@omochice/redmine@2.3.1/throwable/projects/type";

--- a/denops/ddu-source-redmine/redmine.ts
+++ b/denops/ddu-source-redmine/redmine.ts
@@ -1,6 +1,24 @@
-export { listIssues } from "jsr:@omochice/redmine@2.3.1/result/issues/list";
-export { update as updateIssue } from "jsr:@omochice/redmine@2.3.1/result/issues/update";
-export { fetchList as listProjects } from "jsr:@omochice/redmine@2.3.1/result/projects/list";
+import { ResultAsync } from "npm:neverthrow@8.2.0";
+import { list as listIssuesOrThrow } from "jsr:@omochice/redmine@3.2.0/issues/list";
+import { update as updateIssueOrThrow } from "jsr:@omochice/redmine@3.2.0/issues/update";
+import type { ListIssueQuery } from "jsr:@omochice/redmine@3.2.0/issues/type";
+import { list as listProjectsOrThrow } from "jsr:@omochice/redmine@3.2.0/projects/list";
 
-export type { Issue } from "jsr:@omochice/redmine@2.3.1/throwable/issues/type";
-export type { Project } from "jsr:@omochice/redmine@2.3.1/throwable/projects/type";
+export type { Issue } from "jsr:@omochice/redmine@3.2.0/issues/type";
+export type { Project } from "jsr:@omochice/redmine@3.2.0/projects/type";
+
+type Context = Parameters<typeof listIssuesOrThrow>[0];
+
+/** List every issue visible to the given context. */
+export const listIssues = ResultAsync.fromThrowable(
+  (context: Context, option: ListIssueQuery = {}) =>
+    Array.fromAsync(listIssuesOrThrow(context, option)),
+);
+
+/** List every project visible to the given context. */
+export const listProjects = ResultAsync.fromThrowable(
+  (context: Context) => Array.fromAsync(listProjectsOrThrow(context)),
+);
+
+/** Update the properties of a single issue. */
+export const updateIssue = ResultAsync.fromThrowable(updateIssueOrThrow);


### PR DESCRIPTION
## Summary

Update `@omochice/redmine` to v3.2.0, and report the failures that the issue write actions previously discarded.

## Details

3.x drops the `result`/`throwable` split and exposes a single set of entry points that throw, so the `Result` the call sites branch on no longer comes from the library.

Rather than rewrite five call sites around `try`/`catch`, one module now owns the import and rebuilds the `Result` with neverthrow's `fromThrowable`, which leaves the call sites unchanged and gives the next bump a single place to touch.

The write actions are fixed separately because they discarded their `Result` under 2.x too: a rejected write closed the buffer as if it had been saved.

## Confirmation

Ran `deno task check`, `lint` and `fmt:check` at each of the three commits; all pass.

## Limitation

The repository has no tests, so nothing beyond type checking was verified, and the actions were not exercised against a live Redmine instance.

`note.ts` still sends `private_notes` where the library reads `privateNotes`, so that flag is silently dropped; this predates the bump and is untouched.

The list endpoints now return an `AsyncGenerator`, but items are still materialised with `Array.fromAsync` and enqueued at once rather than streamed per page.

https://claude.ai/code/session_01FkZAhL1A1VCsfFdiGs6kxd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Redmine issue and project listing reliability.
  * Issue updates, notes, and descriptions now provide clearer error messages when changes cannot be saved.
  * Invalid YAML or TOML content is reported without attempting an update.
  * Redmine data handling is more consistent across browsing and editing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->