### PR TITLE
fix: report the issue edit failures that were previously silent

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -15,6 +15,7 @@ import { add } from "jsr:@denops/std@8.2.0/lambda";
 import { expr } from "jsr:@denops/std@8.2.0/eval";
 import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
+import { fromThrowable } from "npm:neverthrow@8.2.0";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
 import { updateIssue as update } from "../../redmine.ts";
 import { assert, is } from "jsr:@core/unknownutil@4.3.0";
@@ -70,24 +71,21 @@ const callback: ActionCallback<Params> = async (args: {
     await modified.setBuffer(d, bufnr, false);
     const lambda = add(d, async (lines: unknown) => {
       assert(lines, is.ArrayOf(is.String));
-      let note: Note;
-      try {
-        const { attrs, body } = extractYaml<NoteOption>(lines.join("\n"));
-        note = {
-          notes: body.trim(),
-          private_notes: attrs.private_notes ?? false,
-        } satisfies Note;
-      } catch {
-        await echoerr(d, `Content is invalid format: ${lines.join("\n")}`);
-        return;
-      }
-      const result = await update(item, item.issue.id, note);
-      if (result.isErr()) {
-        await echoerr(
-          d,
-          `Failed to add a note to issue #${item.issue.id}: ${result.error}`,
-        );
-      }
+      const text = lines.join("\n");
+      await fromThrowable(() => extractYaml<NoteOption>(text))()
+        .map(({ attrs, body }) =>
+          ({
+            notes: body.trim(),
+            private_notes: attrs.private_notes ?? false,
+          }) satisfies Note
+        )
+        .mapErr(() => `Content is invalid format: ${text}`)
+        .asyncAndThen((note) =>
+          update(item, item.issue.id, note).mapErr((cause) =>
+            `Failed to add a note to issue #${item.issue.id}: ${cause}`
+          )
+        )
+        .match(() => {}, (message) => echoerr(d, message));
     });
 
     const command = getEditCommand(actionParams, kindParams);

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -42,18 +42,19 @@ const callback: ActionCallback<Params> = async (args: {
     fragment: `${item.issue.id}`,
   });
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
-  const prepared = await ResultAsync.fromThrowable(async () => {
-    await fn.setbufline(
-      denops,
-      bufnr,
-      1,
-      stringify(item.issue).split(/\r?\n/),
-    );
-    await filetype.setBuffer(denops, bufnr, "toml");
-    await modified.setBuffer(denops, bufnr, false);
-  })();
+  const fillBuffer = ResultAsync.fromThrowable(
+    async (lines: string[]) => {
+      await fn.setbufline(denops, bufnr, 1, lines);
+      await filetype.setBuffer(denops, bufnr, "toml");
+      await modified.setBuffer(denops, bufnr, false);
+    },
+    () => `Failed to prepare the buffer for issue #${item.issue.id}`,
+  );
+  const prepared = await fromThrowable(() => stringify(item.issue))()
+    .mapErr(() => "Convert Error: the issue cannot convert to toml format")
+    .asyncAndThen((toml) => fillBuffer(toml.split(/\r?\n/)));
   if (prepared.isErr()) {
-    echoerr(denops, "Convert Error: the issue cannot convert to toml format");
+    await echoerr(denops, prepared.error);
     return ActionFlags.None;
   }
 

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -13,7 +13,7 @@ import { add } from "jsr:@denops/std@8.2.0/lambda";
 import { expr } from "jsr:@denops/std@8.2.0/eval";
 import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
-import { fromThrowable } from "npm:neverthrow@8.2.0";
+import { fromThrowable, ResultAsync } from "npm:neverthrow@8.2.0";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
 import { updateIssue } from "../../redmine.ts";
 import { isItem, type Params } from "../type.ts";
@@ -42,7 +42,7 @@ const callback: ActionCallback<Params> = async (args: {
     fragment: `${item.issue.id}`,
   });
   const bufnr = await prepareUnwritableBuffer(denops, bufname);
-  try {
+  const prepared = await ResultAsync.fromThrowable(async () => {
     await fn.setbufline(
       denops,
       bufnr,
@@ -51,7 +51,8 @@ const callback: ActionCallback<Params> = async (args: {
     );
     await filetype.setBuffer(denops, bufnr, "toml");
     await modified.setBuffer(denops, bufnr, false);
-  } catch {
+  })();
+  if (prepared.isErr()) {
     echoerr(denops, "Convert Error: the issue cannot convert to toml format");
     return ActionFlags.None;
   }

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -13,6 +13,7 @@ import { add } from "jsr:@denops/std@8.2.0/lambda";
 import { expr } from "jsr:@denops/std@8.2.0/eval";
 import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
+import { fromThrowable } from "npm:neverthrow@8.2.0";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
 import { updateIssue } from "../../redmine.ts";
 import { isItem, type Params } from "../type.ts";
@@ -57,27 +58,15 @@ const callback: ActionCallback<Params> = async (args: {
 
   const lambda = add(denops, async (lines: unknown) => {
     assert(lines, is.ArrayOf(is.String));
-    let content: ReturnType<typeof parse>;
-    try {
-      content = parse(lines.join("\n"));
-    } catch {
-      await echoerr(
-        denops,
-        `Content is invalid toml format: ${lines.join("\n")}`,
-      );
-      return;
-    }
-    const result = await updateIssue(
-      item,
-      item.issue.id,
-      content,
-    );
-    if (result.isErr()) {
-      await echoerr(
-        denops,
-        `Failed to update issue #${item.issue.id}: ${result.error}`,
-      );
-    }
+    const text = lines.join("\n");
+    await fromThrowable(() => parse(text))()
+      .mapErr(() => `Content is invalid toml format: ${text}`)
+      .asyncAndThen((content) =>
+        updateIssue(item, item.issue.id, content).mapErr((cause) =>
+          `Failed to update issue #${item.issue.id}: ${cause}`
+        )
+      )
+      .match(() => {}, (message) => echoerr(denops, message));
   });
 
   const command = getEditCommand(actionParams, kindParams);

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -15,11 +15,14 @@ import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
 import { stringify } from "jsr:@std/yaml@1.2.0";
 import { extractYaml } from "jsr:@std/front-matter@1.0.9";
+import { err, fromThrowable, ok } from "npm:neverthrow@8.2.0";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
 import { updateIssue } from "../../redmine.ts";
 import { isItem, type Params } from "../type.ts";
 import { as, assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { getEditCommand } from "../getEditCommand.ts";
+
+const isAttrs = is.ObjectOf({ title: as.Optional(is.String) });
 
 const callback: ActionCallback<Params> = async (args: {
   denops: Denops;
@@ -67,19 +70,23 @@ const callback: ActionCallback<Params> = async (args: {
 
     const lambda = add(d, async (lines: unknown) => {
       assert(lines, is.ArrayOf(is.String));
-      const { attrs, body } = extractYaml(lines.join("\n").trim());
-      assert(attrs, is.ObjectOf({ title: as.Optional(is.String) }));
-      const result = await updateIssue(
-        item,
-        item.issue.id,
-        { subject: attrs.title ?? item.issue.subject, description: body },
-      );
-      if (result.isErr()) {
-        await echoerr(
-          d,
-          `Failed to update issue #${item.issue.id}: ${result.error}`,
-        );
-      }
+      const text = lines.join("\n").trim();
+      await fromThrowable(() => extractYaml(text))()
+        .mapErr(() => `Content is invalid format: ${text}`)
+        .andThen(({ attrs, body }) =>
+          isAttrs(attrs)
+            ? ok({
+              subject: attrs.title ?? item.issue.subject,
+              description: body,
+            })
+            : err(`Title in front matter must be a string: ${text}`)
+        )
+        .asyncAndThen((issue) =>
+          updateIssue(item, item.issue.id, issue).mapErr((cause) =>
+            `Failed to update issue #${item.issue.id}: ${cause}`
+          )
+        )
+        .match(() => {}, (message) => echoerr(d, message));
     });
 
     const command = getEditCommand(actionParams, kindParams);


### PR DESCRIPTION
## Summary

Carry every failure in the issue actions as a `Result`, which removes the last `try`/`catch` in the plugin and surfaces failures that previously vanished.

## Details

The client half of each action already returned a `Result` while the parse half threw, so every action carried two error protocols and each `catch` had to be read carefully to know which failures it swallowed.

Two of them swallowed more than intended: the description action guarded neither the front matter parse nor the title check, so a non-string `title` closed the buffer as if the edit had been saved, and the update action reported a failed denops call as a toml conversion error.

`assert(lines, ...)` deliberately keeps throwing in all three actions, because that value comes from denops rather than from the user, so a failure there is a bug rather than bad input.

## Confirmation

Ran `deno task check`, `lint` and `fmt:check` at each of the four commits; all pass.

Confirmed by grep that no `try` or `catch` remains under `denops/`.

## Limitation

The repository has no tests, so nothing beyond type checking was verified, and the actions were not exercised against a live Redmine instance.

The two front-matter actions are now uneven: the description action rejects a non-string `title`, while the note action still reads `private_notes` with no validation and passes any value through.

`stringify` is wrapped only in the update action. The other two calls serialise object literals of primitives that `isItem` guarantees at runtime, so they were judged unable to fail.

https://claude.ai/code/session_01FkZAhL1A1VCsfFdiGs6kxd