### PR TITLE
fix: send the private flag when adding a note

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -17,7 +17,7 @@ import { format } from "jsr:@denops/std@8.2.0/bufname";
 import { filetype, modified } from "jsr:@denops/std@8.2.0/option";
 import { fromThrowable } from "npm:neverthrow@8.2.0";
 import { prepareUnwritableBuffer } from "../prepareBuffer.ts";
-import { updateIssue as update } from "../../redmine.ts";
+import { updateIssue as update, type UpdateIssueQuery } from "../../redmine.ts";
 import { assert, is } from "jsr:@core/unknownutil@4.3.0";
 import { isItem, type Params } from "../type.ts";
 import { getEditCommand } from "../getEditCommand.ts";
@@ -25,10 +25,6 @@ import { getEditCommand } from "../getEditCommand.ts";
 type NoteOption = {
   private_notes?: boolean;
 };
-
-type Note = {
-  notes: string;
-} & NoteOption;
 
 const callback: ActionCallback<Params> = async (args: {
   denops: Denops;
@@ -76,8 +72,8 @@ const callback: ActionCallback<Params> = async (args: {
         .map(({ attrs, body }) =>
           ({
             notes: body.trim(),
-            private_notes: attrs.private_notes ?? false,
-          }) satisfies Note
+            privateNotes: attrs.private_notes ?? false,
+          }) satisfies UpdateIssueQuery
         )
         .mapErr(() => `Content is invalid format: ${text}`)
         .asyncAndThen((note) =>

--- a/denops/ddu-source-redmine/redmine.ts
+++ b/denops/ddu-source-redmine/redmine.ts
@@ -4,7 +4,10 @@ import { update as updateIssueOrThrow } from "jsr:@omochice/redmine@3.2.0/issues
 import type { ListIssueQuery } from "jsr:@omochice/redmine@3.2.0/issues/type";
 import { list as listProjectsOrThrow } from "jsr:@omochice/redmine@3.2.0/projects/list";
 
-export type { Issue } from "jsr:@omochice/redmine@3.2.0/issues/type";
+export type {
+  Issue,
+  UpdateIssueQuery,
+} from "jsr:@omochice/redmine@3.2.0/issues/type";
 export type { Project } from "jsr:@omochice/redmine@3.2.0/projects/type";
 
 type Context = Parameters<typeof listIssuesOrThrow>[0];


### PR DESCRIPTION
## Summary

Send `privateNotes` so that marking a note private actually takes effect.

## Details

The payload spelled the key `private_notes`, but the client reads `privateNotes` and validates with a valibot `object()`, which drops unknown keys rather than rejecting them, so the flag was discarded before the request was built.

Nothing surfaced the loss: the buffer offers `private_notes` in its front matter, the note posted successfully, and it was public.

The literal now satisfies the client's own payload type instead of one declared locally, which is what let the misspelling look correct; reverting the key alone reproduces a type error naming the right spelling.

## Confirmation

Ran `deno task check`, `lint` and `fmt:check` at both commits; all pass.

Restored the old key temporarily and confirmed the type checker now rejects it with "Did you mean to write 'privateNotes'?".

## Limitation

The repository has no tests, and no note was posted against a live Redmine instance, so the flag was not observed taking effect end to end.

The front matter still reads `private_notes`, matching Redmine's REST API rather than the client's camelCase; only the payload was renamed.

https://claude.ai/code/session_01FkZAhL1A1VCsfFdiGs6kxd