### PR TITLE
fix: say what is wrong with the buffer instead of quoting it

### DIFF
--- a/denops/ddu-source-redmine/issue/actions/note.ts
+++ b/denops/ddu-source-redmine/issue/actions/note.ts
@@ -75,7 +75,7 @@ const callback: ActionCallback<Params> = async (args: {
             privateNotes: attrs.private_notes ?? false,
           }) satisfies UpdateIssueQuery
         )
-        .mapErr(() => `Content is invalid format: ${text}`)
+        .mapErr((cause) => `Content is invalid format: ${cause}`)
         .asyncAndThen((note) =>
           update(item, item.issue.id, note).mapErr((cause) =>
             `Failed to add a note to issue #${item.issue.id}: ${cause}`

--- a/denops/ddu-source-redmine/issue/actions/update.ts
+++ b/denops/ddu-source-redmine/issue/actions/update.ts
@@ -62,7 +62,7 @@ const callback: ActionCallback<Params> = async (args: {
     assert(lines, is.ArrayOf(is.String));
     const text = lines.join("\n");
     await fromThrowable(() => parse(text))()
-      .mapErr(() => `Content is invalid toml format: ${text}`)
+      .mapErr((cause) => `Content is invalid toml format: ${cause}`)
       .asyncAndThen((content) =>
         updateIssue(item, item.issue.id, content).mapErr((cause) =>
           `Failed to update issue #${item.issue.id}: ${cause}`

--- a/denops/ddu-source-redmine/issue/actions/updateDescription.ts
+++ b/denops/ddu-source-redmine/issue/actions/updateDescription.ts
@@ -72,14 +72,14 @@ const callback: ActionCallback<Params> = async (args: {
       assert(lines, is.ArrayOf(is.String));
       const text = lines.join("\n").trim();
       await fromThrowable(() => extractYaml(text))()
-        .mapErr(() => `Content is invalid format: ${text}`)
+        .mapErr((cause) => `Content is invalid format: ${cause}`)
         .andThen(({ attrs, body }) =>
           isAttrs(attrs)
             ? ok({
               subject: attrs.title ?? item.issue.subject,
               description: body,
             })
-            : err(`Title in front matter must be a string: ${text}`)
+            : err("Title in front matter must be a string")
         )
         .asyncAndThen((issue) =>
           updateIssue(item, item.issue.id, issue).mapErr((cause) =>


### PR DESCRIPTION
## Summary

Report what the parser threw instead of echoing the whole buffer back, so an edit that fails to parse says where the problem is.

## Details

Every parse failure in the issue actions interpolated the entire buffer into its message, so a typo in the front matter of a long note filled `:messages` with the note itself and left the reader to find the problem unaided.

The parser already reports the line and column, which says more in one line than the content does in fifty.

The title check in the description action is the exception: nothing was thrown there and its message already names the requirement, so it drops the quotation rather than replacing it.

## Confirmation

Ran `deno task check`, `lint` and `fmt:check`; all pass.

Confirmed by grep that no message under `denops/` interpolates the buffer text any more.

## Limitation

The repository has no tests, and no malformed buffer was fed through a running instance, so the exact wording the YAML and TOML parsers produce was not observed.

Raised by Copilot on #214.

https://claude.ai/code/session_01FkZAhL1A1VCsfFdiGs6kxd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for invalid note, update, and description content by showing the parsing cause instead of the full submitted text.
  - Simplified errors for invalid title values, making them clearer and more concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->